### PR TITLE
Add bastion viewer and movement restriction

### DIFF
--- a/src/main/java/com/comugamers/spigot/Main.java
+++ b/src/main/java/com/comugamers/spigot/Main.java
@@ -5,6 +5,8 @@ import com.comugamers.quanta.platform.paper.QuantaPaperPlugin;
 import com.comugamers.quanta.annotations.EnableModules;
 import com.comugamers.quanta.modules.storage.BaseStorageModule;
 import com.comugamers.spigot.listener.BastionBoundaryListener;
+import com.comugamers.quanta.annotations.alias.Autowired;
+import com.comugamers.spigot.service.IEquipoService;
 
 
 @EnableModules({
@@ -13,10 +15,13 @@ import com.comugamers.spigot.listener.BastionBoundaryListener;
 
 public class Main extends QuantaPaperPlugin {
 
+    @Autowired
+    private IEquipoService equipoService;
+
     @Override
     protected void onPluginEnable() {
         getLogger().info("ExamplePlugin has been enabled! This is a placeholder plugin to demonstrate the Quanta platform.");
-        getServer().getPluginManager().registerEvents(new BastionBoundaryListener(), this);
+        getServer().getPluginManager().registerEvents(new BastionBoundaryListener(equipoService), this);
     }
 
     @Override

--- a/src/main/java/com/comugamers/spigot/Main.java
+++ b/src/main/java/com/comugamers/spigot/Main.java
@@ -4,6 +4,7 @@ package com.comugamers.spigot;
 import com.comugamers.quanta.platform.paper.QuantaPaperPlugin;
 import com.comugamers.quanta.annotations.EnableModules;
 import com.comugamers.quanta.modules.storage.BaseStorageModule;
+import com.comugamers.spigot.listener.BastionBoundaryListener;
 
 
 @EnableModules({
@@ -15,6 +16,7 @@ public class Main extends QuantaPaperPlugin {
     @Override
     protected void onPluginEnable() {
         getLogger().info("ExamplePlugin has been enabled! This is a placeholder plugin to demonstrate the Quanta platform.");
+        getServer().getPluginManager().registerEvents(new BastionBoundaryListener(), this);
     }
 
     @Override

--- a/src/main/java/com/comugamers/spigot/command/Bastion1Command.java
+++ b/src/main/java/com/comugamers/spigot/command/Bastion1Command.java
@@ -16,6 +16,10 @@ public class Bastion1Command extends BaseCommand {
 
     @Default
     public void execute(Player player) {
+        if (equipoService.getTeamByMember(player.getUniqueId()) == null) {
+            player.sendMessage("Debes pertenecer a un equipo para usar este comando.");
+            return;
+        }
         Location loc = player.getLocation();
         equipoService.setBastionCorner(player.getUniqueId(), loc.getBlockX(), loc.getBlockZ(), true);
         player.sendMessage("Primera esquina del bastion establecida.");

--- a/src/main/java/com/comugamers/spigot/command/Bastion2Command.java
+++ b/src/main/java/com/comugamers/spigot/command/Bastion2Command.java
@@ -16,6 +16,10 @@ public class Bastion2Command extends BaseCommand {
 
     @Default
     public void execute(Player player) {
+        if (equipoService.getTeamByMember(player.getUniqueId()) == null) {
+            player.sendMessage("Debes pertenecer a un equipo para usar este comando.");
+            return;
+        }
         Location loc = player.getLocation();
         equipoService.setBastionCorner(player.getUniqueId(), loc.getBlockX(), loc.getBlockZ(), false);
         player.sendMessage("Segunda esquina del bastion establecida.");

--- a/src/main/java/com/comugamers/spigot/command/BloquearBastionCommand.java
+++ b/src/main/java/com/comugamers/spigot/command/BloquearBastionCommand.java
@@ -1,0 +1,21 @@
+package com.comugamers.spigot.command;
+
+import com.comugamers.quanta.annotations.alias.Autowired;
+import com.comugamers.spigot.service.IEquipoService;
+import dev.triumphteam.cmd.core.BaseCommand;
+import dev.triumphteam.cmd.core.annotation.Command;
+import dev.triumphteam.cmd.core.annotation.Default;
+import org.bukkit.command.CommandSender;
+
+@Command("bloquearbastion")
+public class BloquearBastionCommand extends BaseCommand {
+
+    @Autowired
+    private IEquipoService equipoService;
+
+    @Default
+    public void execute(CommandSender sender, String teamId) {
+        equipoService.setTeamRestricted(teamId, true);
+        sender.sendMessage("Los jugadores del equipo " + teamId + " no pueden salir de su bastion.");
+    }
+}

--- a/src/main/java/com/comugamers/spigot/command/VerBastionCommand.java
+++ b/src/main/java/com/comugamers/spigot/command/VerBastionCommand.java
@@ -1,0 +1,25 @@
+package com.comugamers.spigot.command;
+
+import com.comugamers.quanta.annotations.alias.Autowired;
+import com.comugamers.spigot.service.IEquipoService;
+import dev.triumphteam.cmd.core.BaseCommand;
+import dev.triumphteam.cmd.core.annotation.Command;
+import dev.triumphteam.cmd.core.annotation.Default;
+import org.bukkit.command.CommandSender;
+
+@Command("verbastion")
+public class VerBastionCommand extends BaseCommand {
+
+    @Autowired
+    private IEquipoService equipoService;
+
+    @Default
+    public void execute(CommandSender sender, String teamId) {
+        int[] coords = equipoService.getBastion(teamId);
+        if (coords == null) {
+            sender.sendMessage("Ese equipo no tiene bastion definido.");
+            return;
+        }
+        sender.sendMessage("Bastion de " + teamId + ": (" + coords[0] + ", " + coords[1] + ") -> (" + coords[2] + ", " + coords[3] + ")");
+    }
+}

--- a/src/main/java/com/comugamers/spigot/listener/BastionBoundaryListener.java
+++ b/src/main/java/com/comugamers/spigot/listener/BastionBoundaryListener.java
@@ -1,0 +1,48 @@
+package com.comugamers.spigot.listener;
+
+import com.comugamers.quanta.annotations.alias.Autowired;
+import com.comugamers.spigot.entity.TeamDataEntity;
+import com.comugamers.spigot.service.IEquipoService;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.Listener;
+import org.bukkit.event.player.PlayerMoveEvent;
+import org.bukkit.entity.Player;
+import org.bukkit.Location;
+
+public class BastionBoundaryListener implements Listener {
+
+    @Autowired
+    private IEquipoService equipoService;
+
+    @EventHandler
+    public void onPlayerMove(PlayerMoveEvent event) {
+        Player player = event.getPlayer();
+        TeamDataEntity team = equipoService.getTeamByMember(player.getUniqueId());
+        if (team == null) {
+            return;
+        }
+        if (!equipoService.isTeamRestricted(team.getId())) {
+            return;
+        }
+        int[] bastion = equipoService.getBastion(team.getId());
+        if (bastion == null) {
+            return;
+        }
+        int minX = Math.min(bastion[0], bastion[2]);
+        int maxX = Math.max(bastion[0], bastion[2]);
+        int minZ = Math.min(bastion[1], bastion[3]);
+        int maxZ = Math.max(bastion[1], bastion[3]);
+
+        Location to = event.getTo();
+        if (to == null) {
+            return;
+        }
+
+        double x = to.getX();
+        double z = to.getZ();
+        if (x < minX || x > maxX || z < minZ || z > maxZ) {
+            event.setCancelled(true);
+            player.sendMessage("No puedes salir de tu bastion.");
+        }
+    }
+}

--- a/src/main/java/com/comugamers/spigot/listener/BastionBoundaryListener.java
+++ b/src/main/java/com/comugamers/spigot/listener/BastionBoundaryListener.java
@@ -1,6 +1,5 @@
 package com.comugamers.spigot.listener;
 
-import com.comugamers.quanta.annotations.alias.Autowired;
 import com.comugamers.spigot.entity.TeamDataEntity;
 import com.comugamers.spigot.service.IEquipoService;
 import org.bukkit.event.EventHandler;
@@ -11,8 +10,11 @@ import org.bukkit.Location;
 
 public class BastionBoundaryListener implements Listener {
 
-    @Autowired
-    private IEquipoService equipoService;
+    private final IEquipoService equipoService;
+
+    public BastionBoundaryListener(IEquipoService equipoService) {
+        this.equipoService = equipoService;
+    }
 
     @EventHandler
     public void onPlayerMove(PlayerMoveEvent event) {

--- a/src/main/java/com/comugamers/spigot/service/IEquipoService.java
+++ b/src/main/java/com/comugamers/spigot/service/IEquipoService.java
@@ -12,8 +12,11 @@ public interface IEquipoService {
         void addMember();
         void leaveTeam();
 
-        TeamDataEntity getTeamByLeader(UUID leader);
-        void setBastionCorner(UUID leader, int x, int z, boolean first);
-        void removeBastion(UUID leader);
-        int[] getBastion(String teamId);
+    TeamDataEntity getTeamByLeader(UUID leader);
+    TeamDataEntity getTeamByMember(UUID playerId);
+    void setBastionCorner(UUID leader, int x, int z, boolean first);
+    void removeBastion(UUID leader);
+    int[] getBastion(String teamId);
+    void setTeamRestricted(String teamId, boolean restricted);
+    boolean isTeamRestricted(String teamId);
 }

--- a/src/main/java/com/comugamers/spigot/service/impl/EquipoServiceImpl.java
+++ b/src/main/java/com/comugamers/spigot/service/impl/EquipoServiceImpl.java
@@ -12,15 +12,19 @@ import com.comugamers.spigot.service.IEquipoService;
 
 import java.util.Map;
 import java.util.Optional;
+import java.util.HashSet;
+import java.util.Set;
 
 @Service
 public class EquipoServiceImpl implements IEquipoService{
 
-	@Autowired
-	private Plugin plugin;
+        @Autowired
+        private Plugin plugin;
 
-	@Autowired
-	private IEquipoRepository repository;
+        @Autowired
+        private IEquipoRepository repository;
+
+        private final Set<String> restrictedTeams = new HashSet<>();
 
 	@Override
 	public boolean createTeam(String id, String displayName, Player player) {
@@ -55,6 +59,19 @@ public class EquipoServiceImpl implements IEquipoService{
     @Override
     public TeamDataEntity getTeamByLeader(UUID leader) {
         return repository.findByLeader(leader);
+    }
+
+    @Override
+    public TeamDataEntity getTeamByMember(UUID playerId) {
+        for (TeamDataEntity team : repository.findAll()) {
+            if (playerId.equals(team.getLeader())) {
+                return team;
+            }
+            if (team.getPlayers() != null && team.getPlayers().contains(playerId)) {
+                return team;
+            }
+        }
+        return null;
     }
 
     @Override
@@ -98,6 +115,20 @@ public class EquipoServiceImpl implements IEquipoService{
             return null;
         }
         return new int[]{team.getBastion1X(), team.getBastion1Z(), team.getBastion2X(), team.getBastion2Z()};
+    }
+
+    @Override
+    public void setTeamRestricted(String teamId, boolean restricted) {
+        if (restricted) {
+            restrictedTeams.add(teamId);
+        } else {
+            restrictedTeams.remove(teamId);
+        }
+    }
+
+    @Override
+    public boolean isTeamRestricted(String teamId) {
+        return restrictedTeams.contains(teamId);
     }
 
 }

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -14,3 +14,7 @@ commands:
     description: Elimina el bastion del equipo
   getbastion:
     description: Obtiene las coordenadas del bastion de un equipo
+  verbastion:
+    description: Muestra el bastion de un equipo
+  bloquearbastion:
+    description: Impide que los jugadores de un equipo salgan de su bastion


### PR DESCRIPTION
## Summary
- add a command to forbid leaving a bastion (`/bloquearbastion`)
- add a command to show a team's bastion (`/verbastion`)
- restrict `/bastion1` and `/bastion2` usage to team members only
- enforce bastion boundaries with a movement listener
- hook listener in the plugin main class
- document new commands in `plugin.yml`

## Testing
- `which mvn` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6857da59e4ac832ea08ec534d76af98d