### PR TITLE
Implement unblock command and improve bastion restriction

### DIFF
--- a/src/main/java/com/comugamers/spigot/command/DesbloquearBastionCommand.java
+++ b/src/main/java/com/comugamers/spigot/command/DesbloquearBastionCommand.java
@@ -1,0 +1,21 @@
+package com.comugamers.spigot.command;
+
+import com.comugamers.quanta.annotations.alias.Autowired;
+import com.comugamers.spigot.service.IEquipoService;
+import dev.triumphteam.cmd.core.BaseCommand;
+import dev.triumphteam.cmd.core.annotation.Command;
+import dev.triumphteam.cmd.core.annotation.Default;
+import org.bukkit.command.CommandSender;
+
+@Command("desbloquearbastion")
+public class DesbloquearBastionCommand extends BaseCommand {
+
+    @Autowired
+    private IEquipoService equipoService;
+
+    @Default
+    public void execute(CommandSender sender, String teamId) {
+        equipoService.setTeamRestricted(teamId, false);
+        sender.sendMessage("Los jugadores del equipo " + teamId + " pueden salir de su bastion nuevamente.");
+    }
+}

--- a/src/main/java/com/comugamers/spigot/listener/BastionBoundaryListener.java
+++ b/src/main/java/com/comugamers/spigot/listener/BastionBoundaryListener.java
@@ -7,10 +7,16 @@ import org.bukkit.event.Listener;
 import org.bukkit.event.player.PlayerMoveEvent;
 import org.bukkit.entity.Player;
 import org.bukkit.Location;
+import org.bukkit.util.Vector;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.UUID;
 
 public class BastionBoundaryListener implements Listener {
 
     private final IEquipoService equipoService;
+    private final Map<UUID, Long> lastMessageTime = new HashMap<>();
 
     public BastionBoundaryListener(IEquipoService equipoService) {
         this.equipoService = equipoService;
@@ -44,7 +50,18 @@ public class BastionBoundaryListener implements Listener {
         double z = to.getZ();
         if (x < minX || x > maxX || z < minZ || z > maxZ) {
             event.setCancelled(true);
-            player.sendMessage("No puedes salir de tu bastion.");
+
+            long now = System.currentTimeMillis();
+            Long last = lastMessageTime.get(player.getUniqueId());
+            if (last == null || now - last > 2000) {
+                player.sendMessage("No puedes salir de tu bastion.");
+                lastMessageTime.put(player.getUniqueId(), now);
+            }
+
+            Vector knockback = event.getFrom().toVector().subtract(to.toVector()).normalize().multiply(0.5);
+            knockback.setY(0.3);
+            player.setVelocity(knockback);
+            player.damage(4.0);
         }
     }
 }

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -18,3 +18,5 @@ commands:
     description: Muestra el bastion de un equipo
   bloquearbastion:
     description: Impide que los jugadores de un equipo salgan de su bastion
+  desbloquearbastion:
+    description: Permite nuevamente salir del bastion al equipo indicado


### PR DESCRIPTION
## Summary
- add `/desbloquearbastion` command to allow teams to leave their bastion
- add knockback and damage when blocked players try leaving
- throttle escape warning message

## Testing
- `mvn -q -DskipTests=true package` *(fails: `mvn: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_6857e15a84d0832e9f43a0e787d8508a