### PR TITLE
Add attack zone teleportation

### DIFF
--- a/src/main/java/com/comugamers/spigot/Main.java
+++ b/src/main/java/com/comugamers/spigot/Main.java
@@ -5,6 +5,7 @@ import com.comugamers.quanta.platform.paper.QuantaPaperPlugin;
 import com.comugamers.quanta.annotations.EnableModules;
 import com.comugamers.quanta.modules.storage.BaseStorageModule;
 import com.comugamers.spigot.listener.BastionBoundaryListener;
+import com.comugamers.spigot.listener.PvpAttackListener;
 import com.comugamers.quanta.annotations.alias.Autowired;
 import com.comugamers.spigot.service.IEquipoService;
 
@@ -22,6 +23,7 @@ public class Main extends QuantaPaperPlugin {
     protected void onPluginEnable() {
         getLogger().info("ExamplePlugin has been enabled! This is a placeholder plugin to demonstrate the Quanta platform.");
         getServer().getPluginManager().registerEvents(new BastionBoundaryListener(equipoService), this);
+        getServer().getPluginManager().registerEvents(new PvpAttackListener(equipoService), this);
     }
 
     @Override

--- a/src/main/java/com/comugamers/spigot/command/IniciarAtaqueCommand.java
+++ b/src/main/java/com/comugamers/spigot/command/IniciarAtaqueCommand.java
@@ -1,0 +1,27 @@
+package com.comugamers.spigot.command;
+
+import com.comugamers.quanta.annotations.alias.Autowired;
+import com.comugamers.spigot.entity.TeamDataEntity;
+import com.comugamers.spigot.service.IEquipoService;
+import dev.triumphteam.cmd.core.BaseCommand;
+import dev.triumphteam.cmd.core.annotation.Command;
+import dev.triumphteam.cmd.core.annotation.Default;
+import org.bukkit.command.CommandSender;
+
+@Command("iniciarataque")
+public class IniciarAtaqueCommand extends BaseCommand {
+
+    @Autowired
+    private IEquipoService equipoService;
+
+    @Default
+    public void execute(CommandSender sender, String teamId) {
+        TeamDataEntity team = equipoService.getTeamById(teamId);
+        if (team == null) {
+            sender.sendMessage("El equipo especificado no existe.");
+            return;
+        }
+        equipoService.startAttackPhase(teamId);
+        sender.sendMessage("Fase de ataque iniciada para " + teamId + ".");
+    }
+}

--- a/src/main/java/com/comugamers/spigot/command/ObjetivoPvpCommand.java
+++ b/src/main/java/com/comugamers/spigot/command/ObjetivoPvpCommand.java
@@ -1,0 +1,27 @@
+package com.comugamers.spigot.command;
+
+import com.comugamers.quanta.annotations.alias.Autowired;
+import com.comugamers.spigot.entity.TeamDataEntity;
+import com.comugamers.spigot.service.IEquipoService;
+import dev.triumphteam.cmd.core.BaseCommand;
+import dev.triumphteam.cmd.core.annotation.Command;
+import dev.triumphteam.cmd.core.annotation.Default;
+import org.bukkit.command.CommandSender;
+
+@Command("objetivopvp")
+public class ObjetivoPvpCommand extends BaseCommand {
+
+    @Autowired
+    private IEquipoService equipoService;
+
+    @Default
+    public void execute(CommandSender sender, String teamId) {
+        TeamDataEntity team = equipoService.getTeamById(teamId);
+        if (team == null) {
+            sender.sendMessage("El equipo especificado no existe.");
+            return;
+        }
+        equipoService.setAttackTarget(teamId);
+        sender.sendMessage("PVP habilitado contra el equipo " + teamId + ".");
+    }
+}

--- a/src/main/java/com/comugamers/spigot/command/SetZonaAtaqueCommand.java
+++ b/src/main/java/com/comugamers/spigot/command/SetZonaAtaqueCommand.java
@@ -1,0 +1,29 @@
+package com.comugamers.spigot.command;
+
+import com.comugamers.quanta.annotations.alias.Autowired;
+import com.comugamers.spigot.entity.TeamDataEntity;
+import com.comugamers.spigot.service.IEquipoService;
+import dev.triumphteam.cmd.core.BaseCommand;
+import dev.triumphteam.cmd.core.annotation.Command;
+import dev.triumphteam.cmd.core.annotation.Default;
+import org.bukkit.entity.Player;
+import org.bukkit.Location;
+
+@Command("setzonaataque")
+public class SetZonaAtaqueCommand extends BaseCommand {
+
+    @Autowired
+    private IEquipoService equipoService;
+
+    @Default
+    public void execute(Player player, String teamId) {
+        TeamDataEntity team = equipoService.getTeamById(teamId);
+        if (team == null) {
+            player.sendMessage("El equipo especificado no existe.");
+            return;
+        }
+        Location loc = player.getLocation();
+        equipoService.setAttackZone(teamId, loc.getBlockX(), loc.getBlockY(), loc.getBlockZ());
+        player.sendMessage("Zona de ataque establecida para el equipo " + teamId + ".");
+    }
+}

--- a/src/main/java/com/comugamers/spigot/entity/TeamDataEntity.java
+++ b/src/main/java/com/comugamers/spigot/entity/TeamDataEntity.java
@@ -27,6 +27,11 @@ public class TeamDataEntity {
     private Integer bastion1Z;
     private Integer bastion2X;
     private Integer bastion2Z;
+
+    // Location where attacking players should be teleported when this team is attacked
+    private Integer attackX;
+    private Integer attackY;
+    private Integer attackZ;
 	public String getId() {
 		return id;
 	}
@@ -69,12 +74,36 @@ public class TeamDataEntity {
 	public void setBastion2X(Integer bastion2x) {
 		bastion2X = bastion2x;
 	}
-	public Integer getBastion2Z() {
-		return bastion2Z;
-	}
-	public void setBastion2Z(Integer bastion2z) {
-		bastion2Z = bastion2z;
-	}
+        public Integer getBastion2Z() {
+                return bastion2Z;
+        }
+        public void setBastion2Z(Integer bastion2z) {
+                bastion2Z = bastion2z;
+        }
+
+        public Integer getAttackX() {
+                return attackX;
+        }
+
+        public void setAttackX(Integer attackX) {
+                this.attackX = attackX;
+        }
+
+        public Integer getAttackY() {
+                return attackY;
+        }
+
+        public void setAttackY(Integer attackY) {
+                this.attackY = attackY;
+        }
+
+        public Integer getAttackZ() {
+                return attackZ;
+        }
+
+        public void setAttackZ(Integer attackZ) {
+                this.attackZ = attackZ;
+        }
     
     
     

--- a/src/main/java/com/comugamers/spigot/listener/PvpAttackListener.java
+++ b/src/main/java/com/comugamers/spigot/listener/PvpAttackListener.java
@@ -1,0 +1,42 @@
+package com.comugamers.spigot.listener;
+
+import com.comugamers.spigot.entity.TeamDataEntity;
+import com.comugamers.spigot.service.IEquipoService;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.Listener;
+import org.bukkit.event.entity.EntityDamageByEntityEvent;
+import org.bukkit.entity.Player;
+
+public class PvpAttackListener implements Listener {
+
+    private final IEquipoService equipoService;
+
+    public PvpAttackListener(IEquipoService equipoService) {
+        this.equipoService = equipoService;
+    }
+
+    @EventHandler
+    public void onDamage(EntityDamageByEntityEvent event) {
+        if (!(event.getDamager() instanceof Player) || !(event.getEntity() instanceof Player)) {
+            return;
+        }
+
+        String target = equipoService.getAttackTarget();
+        if (target == null) {
+            return;
+        }
+
+        Player attacker = (Player) event.getDamager();
+        Player victim = (Player) event.getEntity();
+        TeamDataEntity attackerTeam = equipoService.getTeamByMember(attacker.getUniqueId());
+        TeamDataEntity victimTeam = equipoService.getTeamByMember(victim.getUniqueId());
+        String attackerId = attackerTeam != null ? attackerTeam.getId() : null;
+        String victimId = victimTeam != null ? victimTeam.getId() : null;
+
+        if (target.equals(attackerId) || target.equals(victimId)) {
+            return; // allow attacks involving the target team
+        }
+
+        event.setCancelled(true);
+    }
+}

--- a/src/main/java/com/comugamers/spigot/service/IEquipoService.java
+++ b/src/main/java/com/comugamers/spigot/service/IEquipoService.java
@@ -14,9 +14,14 @@ public interface IEquipoService {
 
     TeamDataEntity getTeamByLeader(UUID leader);
     TeamDataEntity getTeamByMember(UUID playerId);
+    TeamDataEntity getTeamById(String teamId);
     void setBastionCorner(UUID leader, int x, int z, boolean first);
     void removeBastion(UUID leader);
     int[] getBastion(String teamId);
+    void setAttackZone(String teamId, int x, int y, int z);
+    void startAttackPhase(String teamId);
+    void setAttackTarget(String teamId);
+    String getAttackTarget();
     void setTeamRestricted(String teamId, boolean restricted);
     boolean isTeamRestricted(String teamId);
 }

--- a/src/main/java/com/comugamers/spigot/service/impl/EquipoServiceImpl.java
+++ b/src/main/java/com/comugamers/spigot/service/impl/EquipoServiceImpl.java
@@ -24,7 +24,8 @@ public class EquipoServiceImpl implements IEquipoService{
         @Autowired
         private IEquipoRepository repository;
 
-        private final Set<String> restrictedTeams = new HashSet<>();
+    private final Set<String> restrictedTeams = new HashSet<>();
+    private String attackTarget;
 
 	@Override
 	public boolean createTeam(String id, String displayName, Player player) {
@@ -75,6 +76,12 @@ public class EquipoServiceImpl implements IEquipoService{
     }
 
     @Override
+    public TeamDataEntity getTeamById(String teamId) {
+        Optional<TeamDataEntity> opt = repository.findById(teamId);
+        return opt.orElse(null);
+    }
+
+    @Override
     public void setBastionCorner(UUID leader, int x, int z, boolean first) {
         TeamDataEntity team = repository.findByLeader(leader);
         if (team == null) {
@@ -115,6 +122,66 @@ public class EquipoServiceImpl implements IEquipoService{
             return null;
         }
         return new int[]{team.getBastion1X(), team.getBastion1Z(), team.getBastion2X(), team.getBastion2Z()};
+    }
+
+    @Override
+    public void setAttackZone(String teamId, int x, int y, int z) {
+        Optional<TeamDataEntity> opt = repository.findById(teamId);
+        if (opt.isEmpty()) {
+            return;
+        }
+        TeamDataEntity team = opt.get();
+        team.setAttackX(x);
+        team.setAttackY(y);
+        team.setAttackZ(z);
+        repository.save(team);
+    }
+
+    @Override
+    public void setAttackTarget(String teamId) {
+        this.attackTarget = teamId;
+    }
+
+    @Override
+    public String getAttackTarget() {
+        return attackTarget;
+    }
+
+    @Override
+    public void startAttackPhase(String teamId) {
+        Optional<TeamDataEntity> opt = repository.findById(teamId);
+        if (opt.isEmpty()) {
+            return;
+        }
+        TeamDataEntity team = opt.get();
+        if (team.getAttackX() == null || team.getAttackY() == null || team.getAttackZ() == null) {
+            return;
+        }
+
+        for (Player player : plugin.getServer().getOnlinePlayers()) {
+            if (player.isOp()) {
+                continue;
+            }
+
+            TeamDataEntity playerTeam = getTeamByMember(player.getUniqueId());
+            if (playerTeam != null && playerTeam.getId().equals(teamId)) {
+                int[] bastion = getBastion(teamId);
+                if (bastion == null) {
+                    continue;
+                }
+                int minX = Math.min(bastion[0], bastion[2]);
+                int maxX = Math.max(bastion[0], bastion[2]);
+                int minZ = Math.min(bastion[1], bastion[3]);
+                int maxZ = Math.max(bastion[1], bastion[3]);
+                int targetX = (minX + maxX) / 2;
+                int targetZ = (minZ + maxZ) / 2;
+                int targetY = player.getWorld().getHighestBlockYAt(targetX, targetZ) + 1;
+                player.teleport(new org.bukkit.Location(player.getWorld(), targetX + 0.5, targetY, targetZ + 0.5));
+            } else {
+                int y = player.getWorld().getHighestBlockYAt(team.getAttackX(), team.getAttackZ()) + 1;
+                player.teleport(new org.bukkit.Location(player.getWorld(), team.getAttackX() + 0.5, y, team.getAttackZ() + 0.5));
+            }
+        }
     }
 
     @Override

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -20,3 +20,9 @@ commands:
     description: Impide que los jugadores de un equipo salgan de su bastion
   desbloquearbastion:
     description: Permite nuevamente salir del bastion al equipo indicado
+  setzonaataque:
+    description: Define la zona donde se teletransportarán los atacantes de un equipo
+  iniciarataque:
+    description: Teletransporta a los jugadores para iniciar la fase de ataque
+  objetivopvp:
+    description: Permite atacar al equipo indicado sin PVP entre los atacantes


### PR DESCRIPTION
## Summary
- add attacker zone fields in `TeamDataEntity`
- expose new service methods to handle attack zone logic
- implement teleportation for attack phase
- add commands to define and start attack phases
- register new commands in plugin.yml
- add PVP command & listener so only the targeted team can be attacked

## Testing
- `mvn -q -DskipTests package` *(fails: `mvn` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6857e82c9470832e8d2682a81966fc8e