### PR TITLE
Añade plugin de promoción de Twitch

### DIFF
--- a/src/main/java/com/comugamers/spigot/Main.java
+++ b/src/main/java/com/comugamers/spigot/Main.java
@@ -2,16 +2,23 @@ package com.comugamers.spigot;
 
 
 import com.comugamers.quanta.platform.paper.QuantaPaperPlugin;
+import com.comugamers.quanta.annotations.alias.Autowired;
+import com.comugamers.spigot.service.anuncio.IAnuncioService;
 
 public class Main extends QuantaPaperPlugin {
 
+    @Autowired
+    private IAnuncioService anuncioService;
+
     @Override
     protected void onPluginEnable() {
-        getLogger().info("ExamplePlugin has been enabled! This is a placeholder plugin to demonstrate the Quanta platform.");
+        // Iniciamos los anuncios automáticos al habilitar el plugin
+        this.anuncioService.iniciar();
+        getLogger().info("LaJaulaVS Promo Twitch habilitado");
     }
 
     @Override
     protected void onPluginDisable() {
-        getLogger().info("ExamplePlugin has been disabled! Thank you for using the Quanta platform.");
+        getLogger().info("LaJaulaVS Promo Twitch deshabilitado");
     }
 }

--- a/src/main/java/com/comugamers/spigot/command/CambiarTiempoAnuncioCommand.java
+++ b/src/main/java/com/comugamers/spigot/command/CambiarTiempoAnuncioCommand.java
@@ -1,0 +1,30 @@
+package com.comugamers.spigot.command;
+
+import org.bukkit.command.CommandSender;
+
+import com.comugamers.quanta.annotations.alias.Autowired;
+import com.comugamers.spigot.service.anuncio.IAnuncioService;
+
+import dev.triumphteam.cmd.core.BaseCommand;
+import dev.triumphteam.cmd.core.annotation.Command;
+import dev.triumphteam.cmd.core.annotation.Default;
+import dev.triumphteam.cmd.core.annotation.Arg;
+
+@Command("cambiartiempoanuncio")
+public class CambiarTiempoAnuncioCommand extends BaseCommand {
+
+    @Autowired
+    private IAnuncioService anuncioService;
+
+    /**
+     * Ejecuta el comando para cambiar el intervalo entre anuncios.
+     *
+     * @param sender  el remitente del comando
+     * @param minutos intervalo en minutos
+     */
+    @Default
+    public void ejecutar(CommandSender sender, @Arg("minutos") int minutos) {
+        this.anuncioService.cambiarIntervalo(minutos);
+        sender.sendMessage("Intervalo de anuncios actualizado a " + minutos + " minutos.");
+    }
+}

--- a/src/main/java/com/comugamers/spigot/command/CambiarTiempoAnuncioCommand.java
+++ b/src/main/java/com/comugamers/spigot/command/CambiarTiempoAnuncioCommand.java
@@ -8,7 +8,6 @@ import com.comugamers.spigot.service.anuncio.IAnuncioService;
 import dev.triumphteam.cmd.core.BaseCommand;
 import dev.triumphteam.cmd.core.annotation.Command;
 import dev.triumphteam.cmd.core.annotation.Default;
-import dev.triumphteam.cmd.core.annotation.Arg;
 
 @Command("cambiartiempoanuncio")
 public class CambiarTiempoAnuncioCommand extends BaseCommand {
@@ -23,7 +22,7 @@ public class CambiarTiempoAnuncioCommand extends BaseCommand {
      * @param minutos intervalo en minutos
      */
     @Default
-    public void ejecutar(CommandSender sender, @Arg("minutos") int minutos) {
+    public void ejecutar(CommandSender sender, int minutos) {
         this.anuncioService.cambiarIntervalo(minutos);
         sender.sendMessage("Intervalo de anuncios actualizado a " + minutos + " minutos.");
     }

--- a/src/main/java/com/comugamers/spigot/service/anuncio/IAnuncioService.java
+++ b/src/main/java/com/comugamers/spigot/service/anuncio/IAnuncioService.java
@@ -1,0 +1,20 @@
+package com.comugamers.spigot.service.anuncio;
+
+import com.google.inject.ImplementedBy;
+import com.comugamers.spigot.service.anuncio.impl.AnuncioServiceImpl;
+
+@ImplementedBy(AnuncioServiceImpl.class)
+public interface IAnuncioService {
+
+    /**
+     * Inicia el ciclo de anuncios con el intervalo por defecto.
+     */
+    void iniciar();
+
+    /**
+     * Cambia el intervalo de tiempo entre anuncios en minutos.
+     * 
+     * @param minutos nuevo intervalo en minutos
+     */
+    void cambiarIntervalo(int minutos);
+}

--- a/src/main/java/com/comugamers/spigot/service/anuncio/impl/AnuncioServiceImpl.java
+++ b/src/main/java/com/comugamers/spigot/service/anuncio/impl/AnuncioServiceImpl.java
@@ -1,0 +1,59 @@
+package com.comugamers.spigot.service.anuncio.impl;
+
+import java.util.Arrays;
+import java.util.List;
+
+import org.bukkit.Bukkit;
+import org.bukkit.ChatColor;
+import org.bukkit.plugin.Plugin;
+import org.bukkit.scheduler.BukkitTask;
+
+import com.comugamers.quanta.annotations.Service;
+import com.comugamers.quanta.annotations.alias.Autowired;
+import com.comugamers.spigot.service.anuncio.IAnuncioService;
+
+@Service
+public class AnuncioServiceImpl implements IAnuncioService {
+
+    @Autowired
+    private Plugin plugin;
+
+    private final List<String> mensajes = Arrays.asList(
+            "&6&lBienvenidos a &c&lDefiende el basti\u00f3n&6&l, &fno olvides seguir el directo en &d&ntwitch.tv/lajaulavs",
+            "&eRecuerda que puedes conseguir boletos usando &a!chicklin &een el canal de &bLaJaulaVS&e, canjea &6Soy un real &ey ve a la web para obtener tu primera &a!chicklin",
+            "&bSigue el evento en &d&ntwitch.tv/lajaulavs &by te ver\u00e1s como &6&lprotagonista &bparticipando"
+    );
+
+    private int intervaloMinutos = 20;
+    private BukkitTask tarea;
+    private int indice = 0;
+
+    @Override
+    public void iniciar() {
+        programarTarea();
+    }
+
+    @Override
+    public void cambiarIntervalo(int minutos) {
+        if (minutos <= 0) {
+            minutos = 1;
+        }
+        this.intervaloMinutos = minutos;
+        if (this.tarea != null) {
+            this.tarea.cancel();
+        }
+        programarTarea();
+    }
+
+    /**
+     * Programa la tarea repetitiva que env\u00eda los mensajes.
+     */
+    private void programarTarea() {
+        long ticks = this.intervaloMinutos * 60L * 20L;
+        this.tarea = Bukkit.getScheduler().runTaskTimer(this.plugin, () -> {
+            String texto = mensajes.get(indice);
+            Bukkit.broadcastMessage(ChatColor.translateAlternateColorCodes('&', texto));
+            indice = (indice + 1) % mensajes.size();
+        }, ticks, ticks);
+    }
+}

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -1,4 +1,4 @@
-name: pluginPrueba
+name: lajaulavsPromoTwitch
 api: "1.13"
 main: com.comugamers.spigot.Main
 version: "1.0"


### PR DESCRIPTION
## Summary
- cambia el nombre en `plugin.yml`
- agrega servicio de anuncios programados con opción de cambio de intervalo
- implementa el comando `/cambiartiempoanuncio`
- ajusta `Main` para iniciar anuncios al habilitar el plugin

## Testing
- `mvn -q -DskipTests package` *(falló: mvn no encontrado)*

------
https://chatgpt.com/codex/tasks/task_e_685aaee8cb50832eba60a4ef818a3b8e