### PR TITLE
Añadir gestión de invitaciones y expulsiones en equipos

### DIFF
--- a/src/main/java/com/comugamers/spigot/command/EquipoCommand.java
+++ b/src/main/java/com/comugamers/spigot/command/EquipoCommand.java
@@ -41,4 +41,60 @@ public class EquipoCommand extends BaseCommand {
             sender.sendMessage("Equipo ya existente");
         }
     }
+
+    @SubCommand("invitar")
+    public void invitar(CommandSender sender, Player objetivo) {
+        if (!(sender instanceof Player)) {
+            sender.sendMessage("Este comando debe ser ejecutado desde el juego.");
+            return;
+        }
+        Player jugador = (Player) sender;
+        if (equipoService.inviteMember(jugador, objetivo)) {
+            sender.sendMessage("Invitación enviada a " + objetivo.getName());
+        } else {
+            sender.sendMessage("No se pudo enviar la invitación.");
+        }
+    }
+
+    @SubCommand("aceptar")
+    public void aceptar(CommandSender sender) {
+        if (!(sender instanceof Player)) {
+            sender.sendMessage("Este comando debe ser ejecutado desde el juego.");
+            return;
+        }
+        Player jugador = (Player) sender;
+        if (equipoService.acceptInvite(jugador)) {
+            sender.sendMessage("Has aceptado la invitación.");
+        } else {
+            sender.sendMessage("No tienes invitaciones pendientes.");
+        }
+    }
+
+    @SubCommand("rechazar")
+    public void rechazar(CommandSender sender) {
+        if (!(sender instanceof Player)) {
+            sender.sendMessage("Este comando debe ser ejecutado desde el juego.");
+            return;
+        }
+        Player jugador = (Player) sender;
+        if (equipoService.rejectInvite(jugador)) {
+            sender.sendMessage("Has rechazado la invitación.");
+        } else {
+            sender.sendMessage("No tienes invitaciones pendientes.");
+        }
+    }
+
+    @SubCommand("expulsar")
+    public void expulsar(CommandSender sender, Player objetivo) {
+        if (!(sender instanceof Player)) {
+            sender.sendMessage("Este comando debe ser ejecutado desde el juego.");
+            return;
+        }
+        Player jugador = (Player) sender;
+        if (equipoService.kickMember(jugador, objetivo)) {
+            sender.sendMessage("Has expulsado a " + objetivo.getName());
+        } else {
+            sender.sendMessage("No se pudo expulsar al jugador.");
+        }
+    }
 }

--- a/src/main/java/com/comugamers/spigot/service/IEquipoService.java
+++ b/src/main/java/com/comugamers/spigot/service/IEquipoService.java
@@ -9,8 +9,11 @@ import java.util.UUID;
 @ImplementedBy(EquipoServiceImpl.class)
 public interface IEquipoService {
         boolean createTeam(String id, String displayName, Player player);
-        void addMember();
-        void leaveTeam();
+        boolean inviteMember(Player leader, Player target);
+        boolean acceptInvite(Player player);
+        boolean rejectInvite(Player player);
+        boolean kickMember(Player leader, Player target);
+        void leaveTeam(Player player);
 
     TeamDataEntity getTeamByLeader(UUID leader);
     TeamDataEntity getTeamByMember(UUID playerId);


### PR DESCRIPTION
## Summary
- permitir crear, invitar, aceptar/rechazar y expulsar miembros de equipos
- mantener máximo de 4 miembros por equipo

## Testing
- `mvn -q -DskipTests package` *(fails: mvn not found)*

------
https://chatgpt.com/codex/tasks/task_e_685ab6c3164c832e822f780a5b8c2724