### PR TITLE
Mostrar contador a todos al iniciar ataque

### DIFF
--- a/src/main/java/com/comugamers/spigot/Main.java
+++ b/src/main/java/com/comugamers/spigot/Main.java
@@ -7,6 +7,7 @@ import com.comugamers.quanta.modules.storage.BaseStorageModule;
 import com.comugamers.spigot.listener.BastionBoundaryListener;
 import com.comugamers.spigot.listener.PvpAttackListener;
 import com.comugamers.spigot.listener.AttackLeaderDeathListener;
+import com.comugamers.spigot.listener.AttackJoinListener;
 import com.comugamers.quanta.annotations.alias.Autowired;
 import com.comugamers.spigot.service.IEquipoService;
 
@@ -26,6 +27,7 @@ public class Main extends QuantaPaperPlugin {
         getServer().getPluginManager().registerEvents(new BastionBoundaryListener(equipoService), this);
         getServer().getPluginManager().registerEvents(new PvpAttackListener(equipoService), this);
         getServer().getPluginManager().registerEvents(new AttackLeaderDeathListener(equipoService), this);
+        getServer().getPluginManager().registerEvents(new AttackJoinListener(equipoService), this);
     }
 
     @Override

--- a/src/main/java/com/comugamers/spigot/listener/AttackJoinListener.java
+++ b/src/main/java/com/comugamers/spigot/listener/AttackJoinListener.java
@@ -1,0 +1,22 @@
+package com.comugamers.spigot.listener;
+
+import com.comugamers.spigot.service.IEquipoService;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.Listener;
+import org.bukkit.event.player.PlayerJoinEvent;
+import org.bukkit.entity.Player;
+
+public class AttackJoinListener implements Listener {
+
+    private final IEquipoService equipoService;
+
+    public AttackJoinListener(IEquipoService equipoService) {
+        this.equipoService = equipoService;
+    }
+
+    @EventHandler
+    public void onJoin(PlayerJoinEvent event) {
+        Player player = event.getPlayer();
+        equipoService.addPlayerToAttackBar(player);
+    }
+}

--- a/src/main/java/com/comugamers/spigot/service/IEquipoService.java
+++ b/src/main/java/com/comugamers/spigot/service/IEquipoService.java
@@ -29,4 +29,11 @@ public interface IEquipoService {
     String getAttackTarget();
     void setTeamRestricted(String teamId, boolean restricted);
     boolean isTeamRestricted(String teamId);
+
+    /**
+     * Agrega un jugador al contador de ataque si hay uno activo.
+     *
+     * @param player Jugador a agregar.
+     */
+    void addPlayerToAttackBar(Player player);
 }

--- a/src/main/java/com/comugamers/spigot/service/impl/EquipoServiceImpl.java
+++ b/src/main/java/com/comugamers/spigot/service/impl/EquipoServiceImpl.java
@@ -295,6 +295,13 @@ public class EquipoServiceImpl implements IEquipoService{
     }
 
     @Override
+    public void addPlayerToAttackBar(Player player) {
+        if (attackBossBar != null) {
+            attackBossBar.addPlayer(player);
+        }
+    }
+
+    @Override
     public boolean isAttackLeader(UUID uuid) {
         return attackLeader != null && attackLeader.equals(uuid);
     }


### PR DESCRIPTION
## Summary
- agregar `AttackJoinListener` para que el contador sea visible a los jugadores que entren
- exponer método `addPlayerToAttackBar` en `IEquipoService`
- implementar el nuevo método en `EquipoServiceImpl`
- registrar `AttackJoinListener` en `Main`

## Testing
- `apt-get update -y`
- `apt-get install -y maven`
- `mvn -q -DskipTests package` *(falló: Could not transfer artifact org.apache.maven.plugins:maven-resources-plugin)*

------
https://chatgpt.com/codex/tasks/task_e_685abd489144832e8288fe801e34fb3d