### PR TITLE
Implementar selección de cofre para equipos

### DIFF
--- a/src/main/java/com/comugamers/spigot/command/SetCofreCommand.java
+++ b/src/main/java/com/comugamers/spigot/command/SetCofreCommand.java
@@ -1,0 +1,50 @@
+package com.comugamers.spigot.command;
+
+import com.comugamers.quanta.annotations.alias.Autowired;
+import com.comugamers.spigot.entity.TeamDataEntity;
+import com.comugamers.spigot.service.IEquipoService;
+import dev.triumphteam.cmd.core.BaseCommand;
+import dev.triumphteam.cmd.core.annotation.Command;
+import dev.triumphteam.cmd.core.annotation.Default;
+import org.bukkit.Material;
+import org.bukkit.block.Block;
+import org.bukkit.block.Chest;
+import org.bukkit.entity.Player;
+import org.bukkit.inventory.ItemStack;
+
+/**
+ * Comando para asignar un cofre al equipo.
+ * Solo puede usarlo el líder del equipo o un usuario con permisos de op.
+ */
+@Command("setcofre")
+public class SetCofreCommand extends BaseCommand {
+
+    @Autowired
+    private IEquipoService equipoService;
+
+    @Default
+    public void execute(Player player, String teamId) {
+        TeamDataEntity team = equipoService.getTeamById(teamId);
+        if (team == null) {
+            player.sendMessage("El equipo especificado no existe.");
+            return;
+        }
+        if (!player.isOp() && !team.getLeader().equals(player.getUniqueId())) {
+            player.sendMessage("No eres el líder de ese equipo.");
+            return;
+        }
+
+        Block block = player.getTargetBlockExact(5);
+        if (block == null || block.getType() != Material.CHEST) {
+            player.sendMessage("Debes mirar un cofre para seleccionarlo.");
+            return;
+        }
+
+        Chest chest = (Chest) block.getState();
+        ItemStack[] contents = chest.getBlockInventory().getContents();
+        equipoService.setTeamChest(team.getId(), contents);
+        chest.getBlockInventory().clear();
+        block.setType(Material.AIR);
+        player.sendMessage("Cofre guardado para el equipo " + team.getId() + ".");
+    }
+}

--- a/src/main/java/com/comugamers/spigot/service/IEquipoService.java
+++ b/src/main/java/com/comugamers/spigot/service/IEquipoService.java
@@ -31,6 +31,29 @@ public interface IEquipoService {
     boolean isTeamRestricted(String teamId);
 
     /**
+     * Establece el contenido del cofre asociado a un equipo.
+     *
+     * @param teamId  Identificador del equipo.
+     * @param contents Contenido del cofre.
+     */
+    void setTeamChest(String teamId, org.bukkit.inventory.ItemStack[] contents);
+
+    /**
+     * Obtiene el contenido del cofre de un equipo.
+     *
+     * @param teamId Identificador del equipo.
+     * @return Arreglo de ItemStack con el contenido o null si no existe.
+     */
+    org.bukkit.inventory.ItemStack[] getTeamChest(String teamId);
+
+    /**
+     * Elimina el cofre almacenado para un equipo.
+     *
+     * @param teamId Identificador del equipo.
+     */
+    void removeTeamChest(String teamId);
+
+    /**
      * Agrega un jugador al contador de ataque si hay uno activo.
      *
      * @param player Jugador a agregar.

--- a/src/main/java/com/comugamers/spigot/service/impl/EquipoServiceImpl.java
+++ b/src/main/java/com/comugamers/spigot/service/impl/EquipoServiceImpl.java
@@ -41,6 +41,8 @@ public class EquipoServiceImpl implements IEquipoService{
     private final Set<String> restrictedTeams = new HashSet<>();
     // Invitaciones pendientes: jugador -> id del equipo
     private final Map<UUID, String> pendingInvites = new HashMap<>();
+    // Cofres asignados por equipo
+    private final Map<String, org.bukkit.inventory.ItemStack[]> teamChests = new HashMap<>();
     private String attackTarget;
     private BossBar attackBossBar;
     private BukkitTask attackTask;
@@ -274,6 +276,19 @@ public class EquipoServiceImpl implements IEquipoService{
             }
         }
 
+        org.bukkit.inventory.ItemStack[] chest = teamChests.get(teamId);
+        if (chest != null) {
+            Player leaderPlayer = Bukkit.getPlayer(team.getLeader());
+            if (leaderPlayer != null) {
+                for (org.bukkit.inventory.ItemStack item : chest) {
+                    if (item != null && item.getType() != org.bukkit.Material.AIR) {
+                        leaderPlayer.getInventory().addItem(item);
+                    }
+                }
+            }
+            teamChests.remove(teamId);
+        }
+
         startAttackTimer(team);
     }
 
@@ -348,6 +363,21 @@ public class EquipoServiceImpl implements IEquipoService{
     @Override
     public boolean isTeamRestricted(String teamId) {
         return restrictedTeams.contains(teamId);
+    }
+
+    @Override
+    public void setTeamChest(String teamId, org.bukkit.inventory.ItemStack[] contents) {
+        teamChests.put(teamId, contents);
+    }
+
+    @Override
+    public org.bukkit.inventory.ItemStack[] getTeamChest(String teamId) {
+        return teamChests.get(teamId);
+    }
+
+    @Override
+    public void removeTeamChest(String teamId) {
+        teamChests.remove(teamId);
     }
 
     // ----- Scoreboard management -----

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -26,3 +26,5 @@ commands:
     description: Teletransporta a los jugadores para iniciar la fase de ataque
   objetivopvp:
     description: Permite atacar al equipo indicado sin PVP entre los atacantes
+  setcofre:
+    description: Guarda el contenido de un cofre para un equipo


### PR DESCRIPTION
## Summary
- agregar nuevo comando `setcofre`
- manejar cofres por equipo en `EquipoService`
- entregar cofre al líder al iniciar ataque
- documentar comando en `plugin.yml`

## Testing
- `mvn -q -DskipTests package` *(fails: `mvn` not found)*

------
https://chatgpt.com/codex/tasks/task_e_685c672240a4832ebff424ea1b825c2b