### PR TITLE
Fix missing config and Java version

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -3,8 +3,8 @@ plugins {
 }
 
 java {
-    sourceCompatibility = JavaVersion.VERSION_21
-    targetCompatibility = JavaVersion.VERSION_21
+    sourceCompatibility = JavaVersion.VERSION_17
+    targetCompatibility = JavaVersion.VERSION_17
 }
 
 dependencies {

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -1,0 +1,3 @@
+# Configuracion por defecto para BastionSolitario
+# No se usa en el codigo actual pero evita errores al cargar.
+rejoin-delay: 5


### PR DESCRIPTION
## Summary
- add a default `config.yml` so `saveDefaultConfig()` does not fail
- set Gradle Java version to 17 as requested

## Testing
- `gradle test` *(fails: could not resolve dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_685f0a013014832eab7d8028378fa125