### PR TITLE
Implement corner marking commands

### DIFF
--- a/src/main/java/gg/lajaulavs/bastion/RoundManager.java
+++ b/src/main/java/gg/lajaulavs/bastion/RoundManager.java
@@ -30,7 +30,7 @@ public class RoundManager {
             Player player = entry.getKey();
             Territory t = territoryManager.getTerritory(entry.getValue());
             if (t != null) {
-                player.teleport(t.getCorner1());
+                player.teleport(t.getCenter());
             }
         }
 

--- a/src/main/java/gg/lajaulavs/bastion/Territory.java
+++ b/src/main/java/gg/lajaulavs/bastion/Territory.java
@@ -4,8 +4,8 @@ import org.bukkit.Location;
 
 public class Territory {
     private final String id;
-    private final Location corner1;
-    private final Location corner2;
+    private Location corner1;
+    private Location corner2;
     private String ownerTeam;
     private int points;
     private long lastClaimedTick;
@@ -19,6 +19,14 @@ public class Territory {
     public String getId() { return id; }
     public Location getCorner1() { return corner1; }
     public Location getCorner2() { return corner2; }
+    public void setCorner1(Location corner1) { this.corner1 = corner1; }
+    public void setCorner2(Location corner2) { this.corner2 = corner2; }
+    public Location getCenter() {
+        double x = (corner1.getX() + corner2.getX()) / 2.0;
+        double y = (corner1.getY() + corner2.getY()) / 2.0;
+        double z = (corner1.getZ() + corner2.getZ()) / 2.0;
+        return new Location(corner1.getWorld(), x, y, z);
+    }
     public String getOwnerTeam() { return ownerTeam; }
     public void setOwnerTeam(String ownerTeam) { this.ownerTeam = ownerTeam; }
     public int getPoints() { return points; }

--- a/src/main/java/gg/lajaulavs/bastion/TerritoryManager.java
+++ b/src/main/java/gg/lajaulavs/bastion/TerritoryManager.java
@@ -65,6 +65,20 @@ public class TerritoryManager {
 
     public Territory getTerritory(String id) { return territories.get(id); }
 
+    public void setCorner1(String id, Location loc) {
+        Territory t = territories.get(id);
+        if (t != null) {
+            t.setCorner1(loc);
+        }
+    }
+
+    public void setCorner2(String id, Location loc) {
+        Territory t = territories.get(id);
+        if (t != null) {
+            t.setCorner2(loc);
+        }
+    }
+
     public void saveTerritories() {
         FileConfiguration cfg = new YamlConfiguration();
         for (Map.Entry<String, Territory> entry : territories.entrySet()) {

--- a/src/main/java/gg/lajaulavs/bastion/command/BastionCommand.java
+++ b/src/main/java/gg/lajaulavs/bastion/command/BastionCommand.java
@@ -3,6 +3,7 @@ package gg.lajaulavs.bastion.command;
 import gg.lajaulavs.bastion.BastionSolitarioPlugin;
 import gg.lajaulavs.bastion.RoundManager;
 import gg.lajaulavs.bastion.TerritoryManager;
+import org.bukkit.Location;
 import org.bukkit.Bukkit;
 import org.bukkit.command.Command;
 import org.bukkit.command.CommandExecutor;
@@ -22,6 +23,7 @@ public class BastionCommand implements CommandExecutor {
     @Override
     public boolean onCommand(CommandSender sender, Command command, String label, String[] args) {
         if (args.length == 0) return false;
+        TerritoryManager territoryManager = plugin.getTerritoryManager();
         if (args[0].equalsIgnoreCase("asignar") && args.length == 3) {
             Player target = Bukkit.getPlayer(args[1]);
             if (target == null) {
@@ -30,6 +32,22 @@ public class BastionCommand implements CommandExecutor {
             }
             plugin.getRoundManager().assign(target, args[2]);
             sender.sendMessage("Asignado " + target.getName() + " a " + args[2]);
+            return true;
+        }
+        if (args[0].equalsIgnoreCase("marcarZona") && args.length == 3 && sender instanceof Player) {
+            Player p = (Player) sender;
+            String id = args[1];
+            Location loc = p.getLocation();
+            if (args[2].equalsIgnoreCase("esquina1")) {
+                territoryManager.setCorner1(id, loc);
+            } else if (args[2].equalsIgnoreCase("esquina2")) {
+                territoryManager.setCorner2(id, loc);
+            } else {
+                sender.sendMessage("Debes indicar esquina1 o esquina2");
+                return true;
+            }
+            territoryManager.saveTerritories();
+            sender.sendMessage("Zona " + id + " actualizada");
             return true;
         }
         if (args[0].equalsIgnoreCase("startRound")) {

--- a/src/test/java/gg/lajaulavs/bastion/TerritoryManagerTest.java
+++ b/src/test/java/gg/lajaulavs/bastion/TerritoryManagerTest.java
@@ -1,6 +1,7 @@
 package gg.lajaulavs.bastion;
 
 import com.github.seeseemelk.mockbukkit.MockBukkit;
+import org.bukkit.Location;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
@@ -24,5 +25,17 @@ public class TerritoryManagerTest {
     public void testDefaultGeneration() {
         TerritoryManager manager = plugin.getTerritoryManager();
         Assertions.assertEquals(20, manager.getTerritories().size());
+    }
+
+    @Test
+    public void testSetCorners() {
+        TerritoryManager manager = plugin.getTerritoryManager();
+        Territory t = manager.getTerritory("A1");
+        Location loc1 = new Location(plugin.getServer().getWorlds().get(0), 10, 5, 10);
+        Location loc2 = new Location(plugin.getServer().getWorlds().get(0), 20, 5, 20);
+        manager.setCorner1("A1", loc1);
+        manager.setCorner2("A1", loc2);
+        Assertions.assertEquals(loc1, t.getCorner1());
+        Assertions.assertEquals(loc2, t.getCorner2());
     }
 }


### PR DESCRIPTION
## Summary
- support updating territory corners
- teleport players to territory centers
- expose `/bs marcarZona <id> <esquina1|esquina2>` for admins
- test new setter logic

## Testing
- `gradle test` *(fails: Could not resolve dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_685f963f2f5c832eba982d5249eba321