### PR TITLE
Add round stop commands

### DIFF
--- a/src/main/java/gg/lajaulavs/bastion/RoundManager.java
+++ b/src/main/java/gg/lajaulavs/bastion/RoundManager.java
@@ -6,6 +6,7 @@ import java.util.Map;
 import org.bukkit.Bukkit;
 import org.bukkit.entity.Player;
 import org.bukkit.scheduler.BukkitRunnable;
+import org.bukkit.scheduler.BukkitTask;
 
 /**
  * Maneja el ciclo de rondas y teleporta a los jugadores a sus territorios.
@@ -14,6 +15,7 @@ public class RoundManager {
     private final BastionSolitarioPlugin plugin;
     private final TerritoryManager territoryManager;
     private final Map<Player, String> assignments = new HashMap<>();
+    private BukkitTask roundTask;
 
     public RoundManager(BastionSolitarioPlugin plugin, TerritoryManager territoryManager) {
         this.plugin = plugin;
@@ -34,7 +36,7 @@ public class RoundManager {
             }
         }
 
-        new BukkitRunnable() {
+        roundTask = new BukkitRunnable() {
             int time = 180;
             @Override
             public void run() {
@@ -51,6 +53,26 @@ public class RoundManager {
     private void endRound() {
         // Resumen simple
         Bukkit.broadcastMessage("La ronda ha terminado.");
+        assignments.clear();
+    }
+
+    /** Detiene la ronda otorgando la victoria al equipo indicado */
+    public void forceWin(String team) {
+        if (roundTask != null) {
+            roundTask.cancel();
+            roundTask = null;
+        }
+        Bukkit.broadcastMessage("La ronda ha sido forzada. Ganador: " + team);
+        endRound();
+    }
+
+    /** Cancela la ronda sin declarar ganador */
+    public void cancelRound() {
+        if (roundTask != null) {
+            roundTask.cancel();
+            roundTask = null;
+        }
+        Bukkit.broadcastMessage("La ronda ha sido cancelada.");
         assignments.clear();
     }
 }

--- a/src/main/java/gg/lajaulavs/bastion/command/BastionCommand.java
+++ b/src/main/java/gg/lajaulavs/bastion/command/BastionCommand.java
@@ -54,6 +54,14 @@ public class BastionCommand implements CommandExecutor {
             plugin.getRoundManager().startRound();
             return true;
         }
+        if (args[0].equalsIgnoreCase("forzarVictoria") && args.length == 2) {
+            plugin.getRoundManager().forceWin(args[1]);
+            return true;
+        }
+        if (args[0].equalsIgnoreCase("cancelarRonda")) {
+            plugin.getRoundManager().cancelRound();
+            return true;
+        }
         return false;
     }
 }


### PR DESCRIPTION
## Summary
- allow forcibly ending a round with a winner
- add command for cancelling the round without a winner

## Testing
- `gradle test` *(fails: Could not resolve dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_685f9a262fd8832eb6bdce578ad1052b