### PR TITLE
Implement attack and defense commands

### DIFF
--- a/src/main/java/gg/lajaulavs/bastion/BastionSolitarioPlugin.java
+++ b/src/main/java/gg/lajaulavs/bastion/BastionSolitarioPlugin.java
@@ -6,12 +6,14 @@ import org.bukkit.plugin.java.JavaPlugin;
 public class BastionSolitarioPlugin extends JavaPlugin {
     private TerritoryManager territoryManager;
     private RoundManager roundManager;
+    private TeamManager teamManager;
 
     @Override
     public void onEnable() {
         saveDefaultConfig();
         territoryManager = new TerritoryManager(this);
-        roundManager = new RoundManager(this, territoryManager);
+        teamManager = new TeamManager();
+        roundManager = new RoundManager(this, territoryManager, teamManager);
         getCommand("bs").setExecutor(new BastionCommand(this));
     }
 
@@ -26,5 +28,9 @@ public class BastionSolitarioPlugin extends JavaPlugin {
 
     public RoundManager getRoundManager() {
         return roundManager;
+    }
+
+    public TeamManager getTeamManager() {
+        return teamManager;
     }
 }

--- a/src/main/java/gg/lajaulavs/bastion/TeamManager.java
+++ b/src/main/java/gg/lajaulavs/bastion/TeamManager.java
@@ -1,0 +1,46 @@
+package gg.lajaulavs.bastion;
+
+import java.util.*;
+import org.bukkit.Bukkit;
+import org.bukkit.entity.Player;
+
+/**
+ * Simple team management.
+ */
+public class TeamManager {
+    private final Map<UUID, String> playerTeams = new HashMap<>();
+    private final Map<String, UUID> teamLeaders = new HashMap<>();
+
+    public void setPlayerTeam(Player player, String team) {
+        playerTeams.put(player.getUniqueId(), team);
+    }
+
+    public String getTeam(Player player) {
+        return playerTeams.get(player.getUniqueId());
+    }
+
+    public void setLeader(String team, Player player) {
+        teamLeaders.put(team, player.getUniqueId());
+        setPlayerTeam(player, team);
+    }
+
+    public boolean isLeader(Player player) {
+        String team = getTeam(player);
+        if (team == null) return false;
+        UUID leaderId = teamLeaders.get(team);
+        return leaderId != null && leaderId.equals(player.getUniqueId());
+    }
+
+    public Collection<Player> getOnlineMembers(String team) {
+        List<Player> members = new ArrayList<>();
+        for (Map.Entry<UUID, String> entry : playerTeams.entrySet()) {
+            if (entry.getValue().equalsIgnoreCase(team)) {
+                Player p = Bukkit.getPlayer(entry.getKey());
+                if (p != null && p.isOnline()) {
+                    members.add(p);
+                }
+            }
+        }
+        return members;
+    }
+}

--- a/src/main/java/gg/lajaulavs/bastion/command/BastionCommand.java
+++ b/src/main/java/gg/lajaulavs/bastion/command/BastionCommand.java
@@ -3,6 +3,7 @@ package gg.lajaulavs.bastion.command;
 import gg.lajaulavs.bastion.BastionSolitarioPlugin;
 import gg.lajaulavs.bastion.RoundManager;
 import gg.lajaulavs.bastion.TerritoryManager;
+import gg.lajaulavs.bastion.TeamManager;
 import org.bukkit.Location;
 import org.bukkit.Bukkit;
 import org.bukkit.command.Command;
@@ -24,14 +25,51 @@ public class BastionCommand implements CommandExecutor {
     public boolean onCommand(CommandSender sender, Command command, String label, String[] args) {
         if (args.length == 0) return false;
         TerritoryManager territoryManager = plugin.getTerritoryManager();
+        RoundManager roundManager = plugin.getRoundManager();
+        TeamManager teamManager = plugin.getTeamManager();
         if (args[0].equalsIgnoreCase("asignar") && args.length == 3) {
             Player target = Bukkit.getPlayer(args[1]);
             if (target == null) {
                 sender.sendMessage("Jugador no encontrado");
                 return true;
             }
-            plugin.getRoundManager().assign(target, args[2]);
+            roundManager.assign(target, args[2]);
             sender.sendMessage("Asignado " + target.getName() + " a " + args[2]);
+            return true;
+        }
+        if (args[0].equalsIgnoreCase("setTeam") && args.length == 3) {
+            Player target = Bukkit.getPlayer(args[1]);
+            if (target == null) {
+                sender.sendMessage("Jugador no encontrado");
+                return true;
+            }
+            teamManager.setPlayerTeam(target, args[2]);
+            sender.sendMessage("Equipo de " + target.getName() + " establecido a " + args[2]);
+            return true;
+        }
+        if (args[0].equalsIgnoreCase("setLeader") && args.length == 3) {
+            Player target = Bukkit.getPlayer(args[1]);
+            if (target == null) {
+                sender.sendMessage("Jugador no encontrado");
+                return true;
+            }
+            teamManager.setLeader(args[2], target);
+            sender.sendMessage("Líder del equipo " + args[2] + " es ahora " + target.getName());
+            return true;
+        }
+        if (args[0].equalsIgnoreCase("marcarAtaque") && args.length == 2 && sender instanceof Player) {
+            Player leader = (Player) sender;
+            roundManager.markAttack(leader, args[1]);
+            return true;
+        }
+        if (args[0].equalsIgnoreCase("atacar") && sender instanceof Player) {
+            Player p = (Player) sender;
+            roundManager.chooseAttack(p);
+            return true;
+        }
+        if (args[0].equalsIgnoreCase("defender") && args.length == 2 && sender instanceof Player) {
+            Player p = (Player) sender;
+            roundManager.chooseDefense(p, args[1]);
             return true;
         }
         if (args[0].equalsIgnoreCase("marcarZona") && args.length == 3 && sender instanceof Player) {
@@ -51,15 +89,15 @@ public class BastionCommand implements CommandExecutor {
             return true;
         }
         if (args[0].equalsIgnoreCase("startRound")) {
-            plugin.getRoundManager().startRound();
+            roundManager.startRound();
             return true;
         }
         if (args[0].equalsIgnoreCase("forzarVictoria") && args.length == 2) {
-            plugin.getRoundManager().forceWin(args[1]);
+            roundManager.forceWin(args[1]);
             return true;
         }
         if (args[0].equalsIgnoreCase("cancelarRonda")) {
-            plugin.getRoundManager().cancelRound();
+            roundManager.cancelRound();
             return true;
         }
         return false;


### PR DESCRIPTION
## Summary
- add a simple `TeamManager`
- update `RoundManager` for team attack and defense logic
- extend `/bs` command with `atacar`, `defender`, `marcarAtaque`, `setTeam`, and `setLeader`
- wire new manager in the plugin

## Testing
- `gradle test` *(fails: Could not resolve PaperMC and other dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_685f9bb76d54832e8590b3930a82e374