### PR TITLE
Autoasignación de ataque/defensa y comando removeLeader

### DIFF
--- a/src/main/java/gg/lajaulavs/bastion/RoundManager.java
+++ b/src/main/java/gg/lajaulavs/bastion/RoundManager.java
@@ -56,6 +56,8 @@ public class RoundManager {
         }
         attackers.add(player.getUniqueId());
         defenders.remove(player.getUniqueId());
+        // Asignar automáticamente la zona de ataque al jugador
+        assign(player, target);
         for (Player member : teamManager.getOnlineMembers(team)) {
             member.sendMessage(player.getName() + " atacará " + target);
         }
@@ -74,6 +76,8 @@ public class RoundManager {
         }
         defenders.put(player.getUniqueId(), territoryId);
         attackers.remove(player.getUniqueId());
+        // Asignar directamente la zona elegida para defender
+        assign(player, territoryId);
         for (Player member : teamManager.getOnlineMembers(team)) {
             member.sendMessage(player.getName() + " defenderá " + territoryId);
         }

--- a/src/main/java/gg/lajaulavs/bastion/TeamManager.java
+++ b/src/main/java/gg/lajaulavs/bastion/TeamManager.java
@@ -24,6 +24,23 @@ public class TeamManager {
         setPlayerTeam(player, team);
     }
 
+    /**
+     * Elimina al jugador como líder si lo es de su equipo.
+     * @return true si se eliminó correctamente
+     */
+    public boolean removeLeader(Player player) {
+        String team = getTeam(player);
+        if (team == null) {
+            return false;
+        }
+        UUID leader = teamLeaders.get(team);
+        if (leader != null && leader.equals(player.getUniqueId())) {
+            teamLeaders.remove(team);
+            return true;
+        }
+        return false;
+    }
+
     public boolean isLeader(Player player) {
         String team = getTeam(player);
         if (team == null) return false;

--- a/src/main/java/gg/lajaulavs/bastion/command/BastionCommand.java
+++ b/src/main/java/gg/lajaulavs/bastion/command/BastionCommand.java
@@ -57,6 +57,19 @@ public class BastionCommand implements CommandExecutor {
             sender.sendMessage("Líder del equipo " + args[2] + " es ahora " + target.getName());
             return true;
         }
+        if (args[0].equalsIgnoreCase("removeLeader") && args.length == 2) {
+            Player target = Bukkit.getPlayer(args[1]);
+            if (target == null) {
+                sender.sendMessage("Jugador no encontrado");
+                return true;
+            }
+            if (teamManager.removeLeader(target)) {
+                sender.sendMessage("Líder quitado a " + target.getName());
+            } else {
+                sender.sendMessage("Ese jugador no es líder");
+            }
+            return true;
+        }
         if (args[0].equalsIgnoreCase("marcarAtaque") && args.length == 2 && sender instanceof Player) {
             Player leader = (Player) sender;
             roundManager.markAttack(leader, args[1]);


### PR DESCRIPTION
## Summary
- asignar automáticamente la zona marcada al usar `/bs atacar`
- asignar la zona elegida al usar `/bs defender`
- añadir método `removeLeader` en `TeamManager`
- nuevo subcomando `/bs removeLeader <jugador>`

## Testing
- `gradle compileJava` *(falló: Could not resolve paper-api y otras dependencias)*

------
https://chatgpt.com/codex/tasks/task_e_6860dedb8a8c832e93b3fb21335ee727